### PR TITLE
Create GenaiMarkdown, an updating Markdown display

### DIFF
--- a/genai/display.py
+++ b/genai/display.py
@@ -1,0 +1,99 @@
+from enum import Enum
+from binascii import hexlify
+from IPython.core import display_functions
+import os
+from typing import Any, Iterator, Union, Optional, Tuple, Dict
+
+
+class Stage(str, Enum):
+    """The stage of feedback generation"""
+
+    STARTING = "starting"
+    GENERATING = "generating"
+    FINISHED = "finished"
+
+
+class GenaiMarkdown:
+    """
+    A class for displaying a markdown string that can be updated in place.
+
+    This class provides an easy way to create and update a Markdown string in Jupyter Notebooks. It
+    supports real-time updates of Markdown content which is useful for emitting ChatGPT suggestions
+    as they are generated.
+
+    Attributes:
+        message (str): The Markdown string to display
+        stage (Optional[Stage]): The current stage of feedback generation
+
+    Example:
+        >>> from genai.display import GenaiMarkdown, Stage
+        ...
+        >>> markdown = UpdatingMarkdown()
+        >>> markdown.append("Hello")
+        >>> markdown.append(" world!")
+        >>> markdown.display()
+        # Displays "Hello world!" in the notebook
+        ...
+        >>> markdown.append(" This is an update!")
+        # Displays "Hello world! This is an update!" in the notebook
+        ...
+        >>> def text_generator():
+        ...    yield " 1"
+        ...    yield " 2"
+        ...    yield " 3"
+        ...
+        >>> markdown.consume(text_generator())
+        # Displays "Hello world! This is an update! 1 2 3" in the notebook
+    """
+
+    def __init__(self, message: str = " ", stage: Optional[Stage] = None) -> None:
+        self._message: str = message
+        self._display_id: str = hexlify(os.urandom(8)).decode('ascii')
+        self._stage: Optional[Stage] = stage
+
+    def append(self, delta: str) -> None:
+        self.message += delta
+
+    def consume(self, delta_generator: Iterator[str]) -> None:
+        for delta in delta_generator:
+            self.append(delta)
+
+    def display(self) -> None:
+        '''Display the `UpdatingMarkdown` with a display ID for receiving updates'''
+        display_functions.display(self, display_id=self._display_id)
+
+    def update_displays(self) -> None:
+        '''Force an update to all displays'''
+        display_functions.display(self, display_id=self._display_id, update=True)
+
+    def __repr__(self) -> str:
+        return self._message
+
+    def _repr_markdown_(self) -> Union[str, Tuple[str, Dict[str, Any]]]:
+        if self._stage is None:
+            return self._message
+
+        metadata = {
+            "genai": {
+                "stage": self._stage,
+            }
+        }
+
+        return self._message, metadata
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+    @message.setter
+    def message(self, value: str) -> None:
+        self._message = value
+        self.update_displays()
+
+    @property
+    def stage(self) -> Optional[Stage]:
+        return self._stage
+
+    @stage.setter
+    def stage(self, stage: Stage) -> None:
+        self._stage = stage

--- a/genai/display.py
+++ b/genai/display.py
@@ -1,8 +1,9 @@
-from enum import Enum
-from binascii import hexlify
-from IPython.core import display_functions
 import os
-from typing import Any, Iterator, Union, Optional, Tuple, Dict
+from binascii import hexlify
+from enum import Enum
+from typing import Any, Dict, Iterator, Optional, Tuple, Union
+
+from IPython.core import display_functions
 
 
 class Stage(str, Enum):

--- a/genai/suggestions.py
+++ b/genai/suggestions.py
@@ -8,8 +8,8 @@ from traceback import TracebackException
 
 from IPython import get_ipython
 
-from genai.generate import generate_exception_suggestion
 from genai.display import GenaiMarkdown, Stage
+from genai.generate import generate_exception_suggestion
 
 
 def can_handle_display_updates():

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def black_check(session: nox_poetry.Session):
 @nox_poetry.session(python="3.9")
 def isort_check(session: nox_poetry.Session):
     session.install("isort")
-    session.run("isort", "--diff", "--check", *LINT_PATHS)
+    session.run("isort", "--diff", "--profile", "black", "--check", *LINT_PATHS)
 
 
 @nox_poetry.session(python="3.9")
@@ -53,4 +53,4 @@ def blacken(session: nox_poetry.Session):
 @nox_poetry.session(python="3.9")
 def isort_apply(session: nox_poetry.Session):
     session.install("isort")
-    session.run("isort", *LINT_PATHS)
+    session.run("isort", *LINT_PATHS, "--profile", "black")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,8 @@
-from genai.context import get_historical_context, repr_genai_pandas, repr_genai
 from unittest.mock import MagicMock, call, patch
 
 import pandas as pd
+
+from genai.context import get_historical_context, repr_genai, repr_genai_pandas
 
 
 class FakeOutput:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest import mock
+from genai.display import GenaiMarkdown, Stage
+from IPython.core import display_functions
+
+
+def test_genai_markdown_init_default(ip):
+    markdown = GenaiMarkdown()
+
+    assert markdown.message == " "
+    assert markdown.stage is None
+
+
+def test_genai_markdown_init_with_args(ip):
+    markdown = GenaiMarkdown(message="Hello world!", stage=Stage.GENERATING)
+
+    assert markdown.message == "Hello world!"
+    assert markdown.stage == Stage.GENERATING
+
+
+def test_genai_markdown_append(ip):
+    markdown = GenaiMarkdown(message="Hello")
+    markdown.append(" world!")
+
+    assert markdown.message == "Hello world!"
+
+
+def test_genai_markdown_consume(ip):
+    markdown = GenaiMarkdown(message="Hello")
+
+    def text_generator():
+        yield " world"
+        yield "!"
+
+    markdown.consume(text_generator())
+
+    assert markdown.message == "Hello world!"
+
+
+def test_genai_markdown_display(ip):
+    markdown = GenaiMarkdown(message="Hello world!")
+
+    with mock.patch.object(display_functions, 'display') as mock_display:
+        markdown.display()
+        mock_display.assert_called_once_with(markdown, display_id=markdown._display_id)
+
+
+def test_genai_markdown_update_displays(ip):
+    markdown = GenaiMarkdown(message="Hello world!")
+
+    with mock.patch.object(display_functions, 'display') as mock_display:
+        markdown.update_displays()
+        mock_display.assert_called_once_with(markdown, display_id=markdown._display_id, update=True)
+
+
+def test_genai_markdown_repr(ip):
+    markdown = GenaiMarkdown(message="Hello world!")
+
+    assert repr(markdown) == "Hello world!"
+
+
+def test_genai_markdown__repr_markdown_without_stage(ip):
+    markdown = GenaiMarkdown(message="Hello world!")
+
+    result = markdown._repr_markdown_()
+    assert result == "Hello world!"
+
+
+def test_genai_markdown__repr_markdown_with_stage(ip):
+    markdown = GenaiMarkdown(message="Hello world!", stage=Stage.GENERATING)
+
+    result = markdown._repr_markdown_()
+    assert result == ("Hello world!", {"genai": {"stage": Stage.GENERATING}})
+
+
+def test_genai_markdown_message_setter(ip):
+    markdown = GenaiMarkdown(message="Hello")
+
+    with mock.patch.object(markdown, 'update_displays') as mock_update_displays:
+        markdown.message = "Hello world!"
+        mock_update_displays.assert_called_once()
+        assert markdown.message == "Hello world!"
+
+
+def test_genai_markdown_stage_setter(ip):
+    markdown = GenaiMarkdown(stage=None)
+    markdown.stage = Stage.GENERATING
+
+    assert markdown.stage == Stage.GENERATING

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest import mock
-from genai.display import GenaiMarkdown, Stage
+
+import pytest
 from IPython.core import display_functions
+
+from genai.display import GenaiMarkdown, Stage
 
 
 def test_genai_markdown_init_default(ip):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,6 +1,5 @@
-from unittest import mock
-
 import sys
+from unittest import mock
 
 from genai import generate
 

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,8 +1,7 @@
 import sys
 from unittest import mock
 
-from genai import suggestions, generate
-
+from genai import generate, suggestions
 from genai.suggestions import can_handle_display_updates
 
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,4 +1,4 @@
-from genai.tokens import num_tokens_from_messages, trim_messages_to_fit_token_limit, MAX_TOKENS
+from genai.tokens import MAX_TOKENS, num_tokens_from_messages, trim_messages_to_fit_token_limit
 
 
 def test_num_tokens_from_messages():


### PR DESCRIPTION
This creates a simple updating markdown display for usage by the exception suggestions and future development of `%%assist`.

![genai-markdown](https://user-images.githubusercontent.com/836375/226186661-5d70b289-0a00-433d-86ef-20498bca7f41.gif)



