### PR TITLE
create a more ipythonic context manager

### DIFF
--- a/genai/context.py
+++ b/genai/context.py
@@ -92,7 +92,7 @@ ignore_tokens = [
 def build_context(history_manager, start=1, stop=None):
     context = Context()
 
-    for (session, execution_counter, cell_text) in history_manager.get_range(
+    for session, execution_counter, cell_text in history_manager.get_range(
         session=0, start=start, stop=stop
     ):
         print('session', session)

--- a/genai/context.py
+++ b/genai/context.py
@@ -1,9 +1,7 @@
 """
 Creates user and system messages as context for ChatGPT, using the history of the current IPython session.
 """
-from typing import Any, Dict, List, Optional
-
-from IPython.core.interactiveshell import InteractiveShell
+from typing import Any, Dict, Optional
 
 try:
     import pandas as pd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ def session_ip():
 
 @pytest.fixture(scope="function")
 def ip(session_ip):
+    session_ip.execution_count = 1
     session_ip.run_line_magic(magic_name="load_ext", line="genai")
     yield session_ip
     session_ip.run_line_magic(magic_name="unload_ext", line="genai")


### PR DESCRIPTION
1. Introduced a `Context` class to capture IPython history as `ChatCompletion` compatible messages while retaining execution count
2. Replaced the `get_historical_context` function with the `build_context` function, which constructs the context using the new Context class.
3. Updated `%%assist` to use `build_context` and trim down the messages based on estimated token size