### PR TITLE
Meta: create_gpt_magic to allow setting up new OpenAI backed magics quickly

### DIFF
--- a/genai/metamagic.py
+++ b/genai/metamagic.py
@@ -30,7 +30,7 @@ def create_gpt_magic(magic_name, prompt, generate_context=None, model="gpt-3.5-t
 
         # Create the response from ChatCompletion
         response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+            model=model,
             messages=[
                 # Establish the context of the conversation
                 {

--- a/genai/metamagic.py
+++ b/genai/metamagic.py
@@ -1,0 +1,47 @@
+import openai
+from IPython import get_ipython
+
+from genai.display import GenaiMarkdown
+from genai.generate import deltas
+
+# Creating a setup that will make it easy to define new magics
+# that rely on a prompt and a response. This will be useful for
+# defining a magic that will allow the user to define a prompt
+# and then generate a response to that prompt.
+
+
+def create_gpt_magic(magic_name, prompt, generate_context=None, model="gpt-3.5-turbo"):
+    # Define a cell magic that uses `magic_name`
+
+    def magic(line, cell):
+        gm = GenaiMarkdown(execution_count=get_ipython().execution_count)
+        gm.display()
+
+        context = []
+        if generate_context:
+            context = generate_context(line=line, cell=cell)
+        else:
+            context = [
+                {
+                    "role": "user",
+                    "content": cell,
+                },
+            ]
+
+        # Create the response from ChatCompletion
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                # Establish the context of the conversation
+                {
+                    "role": "system",
+                    "content": prompt,
+                },
+                *context,
+            ],
+            stream=True,
+        )
+
+        gm.consume(deltas(response))
+
+    get_ipython().register_magic_function(magic, magic_kind="cell", magic_name=magic_name)


### PR DESCRIPTION
Provide a `create_gpt_magic`.

This idea spawned from [@jph00's tweet](https://twitter.com/jeremyphoward/status/1637331369578876928) and what I've been hoping for in #42.

> Someone told me that when they ask ChatGPT for an explanation, they ask for it "in the style of Jeremy Howard", since (they said) it results in a clearer answer. I tried it on Bing, then it suggested I ask how it knows my style, and then suggested I ask it whether it likes it :D

This PR adds a few things (building on #66):

* Use previous genai emitted markdown as an assistant message so you can continue the conversation
* Enable a simple way to create gpt magics inline with `create_gpt_magic`

To try this out, create the following cells:

```python
%pip install genai==1.1.0-pre.1
%load_ext genai
```

Second cell:

```python
# genai:ignore
from genai.metamagic import create_gpt_magic

JEREMY_PROMPT = f"""
Greetings coders!

Today, we will be learning how to write code in Python within Jupyter Notebooks. As your trusty assistant, my job is to help you with this task.

Now, here's the trick: when you start your message with `%%jeremy`, you're talking to me! Otherwise, you're speaking to IPython / Jupyter.

In order to help you write your code, I'll be providing comments and sample code for you to read and edit. My goal is to make sure that your code runs successfully without any issues. So don't be afraid to ask me any questions along the way.

Are you ready? Let's get coding!
""".strip()

create_gpt_magic(
    "jeremy",
    prompt=JEREMY_PROMPT,
    model="gpt-4"
)
```

Then use `%%jeremy` wherever you like:

```
%%jeremy

How could we visualize the pigeonhole principle?
```

Result (for entertainment):

![image](https://user-images.githubusercontent.com/836375/226220164-afe0ac58-2dcf-45a4-8180-4ac1a2df4f99.png)
