### PR TITLE
chore: move configurations to `pyproject.toml`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-warn_unused_configs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,6 @@ omit = ["genai/_version.py"]
 [tool.mypy]
 ignore_missing_imports = true
 warn_unused_configs = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,7 @@ exclude_lines = ["if self.debug:",
                  "if __name__ == '__main__':"]
 ignore_errors = true
 omit = ["genai/_version.py"]
+
+[tool.mypy]
+ignore_missing_imports = true
+warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ mypy = "^1.1.1"
 requires = ["poetry-core>=1.0.1"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.distutils.bdist_wheel]
+universal = 0
+
 [tool.black]
 line-length = 100
 include = '\.pyi?$'
@@ -101,7 +104,10 @@ exclude_lines = ["if self.debug:",
                  "raise NotImplementedError",
                  "if __name__ == '__main__':"]
 ignore_errors = true
-omit = ["genai/_version.py"]
+omit = [
+  "*/tests/*",
+  "genai/_version.py"
+]
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -109,3 +115,4 @@ warn_unused_configs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+filterwarnings = "always"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-asyncio_mode = auto

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,25 +32,3 @@ ignore =
 max-line-length = 120
 max-complexity = 23
 extend-ignore = E203
-
-[bdist_wheel]
-universal=0
-
-[coverage:run]
-branch = False
-omit =
-    genai/tests/*
-    genai/version.py
-
-[coverage:report]
-exclude_lines =
-    if self\.debug:
-    pragma: no cover
-    raise AssertionError
-    raise NotImplementedError
-    if __name__ == .__main__.:
-ignore_errors = True
-omit = genai/tests/*,genai/_version.py
-
-[tool:pytest]
-filterwarnings = always


### PR DESCRIPTION
This PR aims to minimize the number of configuration files for the project. Instead of a separate `mypy.ini` and `pytest.ini`, we now would have all the configurations within the `pyproject.toml` file leading to a overall minimal code structure.

I managed to transfer most of the configuration files into `pyproject.toml` but flake8 doesn't support it yet (https://github.com/PyCQA/flake8/issues/234).