### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/genai/generate.py
+++ b/genai/generate.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterator, List, TypedDict
 import openai
 
 from genai.prompts import PromptStore
+import litellm
 
 Completion = TypedDict(
     "Completion",
@@ -51,7 +52,7 @@ def generate_next_from_history(
     text: str,
     stream: bool = False,
 ) -> Iterator[str]:
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model="gpt-3.5-turbo",
         messages=[
             # Establish the context of the conversation
@@ -111,7 +112,7 @@ def generate_exception_suggestion(
         },
     )
 
-    response = openai.ChatCompletion.create(
+    response = litellm.completion(
         model="gpt-3.5-turbo",
         messages=messages,
         stream=stream,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ url = "https://pypi.org"
 [tool.poetry.dependencies]
 python = "^3.8"
 openai = "^0.27.0"
+litellm = "^0.1.226"
 ipython = "^8.10.0"
 tabulate = "^0.9.0"
 tiktoken = "^0.3.2"


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic, Replicate API Endpoints

This PR adds support for models from all the above mentioned providers 

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```